### PR TITLE
Use pyzmail36 instead of pyzmail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Jinja2==2.8
 MarkupSafe==0.23
-pyzmail==1.0.3
+pyzmail36==1.0.3

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
       license='Apache License, Version 2.0',
       install_requires=[
             'Jinja2>=2.8',
-            'pyzmail>=1.0.3',
+            'pyzmail36>=1.0.3',
             'skygear>=0.16.0',
       ],
       cmdclass= {'test': PyTest},


### PR DESCRIPTION
The `pyzmail` cannot be installed from pip in python 3.6 and the package
seems unmaintained. A new fork was created by third-party and we switch to
depend on `pyzmail36` instead.

connects #13