### PR TITLE
Add expire_at to forgot password email template

### DIFF
--- a/forgot_password/handlers/forgot_password.py
+++ b/forgot_password/handlers/forgot_password.py
@@ -100,6 +100,7 @@ def register_forgot_password_op(mail_sender, settings):
                 'code': code,
                 'user': user,
                 'user_record': user_record,
+                'expire_at': expire_at,
             }
 
             try:


### PR DESCRIPTION
While the template does not use this param, the user may benefit from
getting the expire_at link if they have custom handling.