### PR TITLE
Introduce URL prefix in Verify user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ to the newly signed up users.
 
 This settings change the behaviour of verifying the user data:
 
+* `VERIFY_URL_PREFIX` - the URL prefix for accessing the Skygear
+  Server. The plugin requires this to generate the reset password link.
+  The value should include protocol (e.g. `https://`).
+
 * `VERIFY_KEYS` - The name of the user record fields which data can be verified.
   Specify multiple keys by separating them with comma. For example, if the
   user record contains the `phone` field and `email` field, specify

--- a/forgot_password/handlers/verify_code.py
+++ b/forgot_password/handlers/verify_code.py
@@ -290,7 +290,7 @@ class VerifyRequestLambda:
         return generate_code(self.settings.keys[record_key].code_format)
 
     def get_template_params(self, record_key, user, user_record, code_str):
-        url_prefix = skyoptions.skygear_endpoint
+        url_prefix = self.settings.url_prefix
         if url_prefix.endswith('/'):
             url_prefix = url_prefix[:-1]
         link = '{0}/user/verify-code/form?code={1}&auth_id={2}'\

--- a/forgot_password/settings.py
+++ b/forgot_password/settings.py
@@ -181,6 +181,10 @@ def get_verify_settings_parser():
     """
     parser = SettingsParser('VERIFY')
 
+    parser.add_setting('url_prefix',
+                       default=getattr(skyoptions, 'skygear_endpoint', None),
+                       required=False)
+
     parser.add_setting(
         'keys',
         atype=get_verify_settings_keys_type(),


### PR DESCRIPTION
Situation
---
By default, the URL prefix of link in user verification is skygear endpoint address. Users, especially use custom domain and self-hosting skygear severs, cannot customise URL prefix.

Expected settings
---
The settings for verify user supports URL prefix like `FORGOT_PASSWORD_URL_PREFIX` in basic settings.

Action
---
1. added parsing rule for `url_prefix` in parser for verify settings (default value is skygear endpoint address)
2. changed to use `url_prefix` in VerifyRequestLambda
3. updated readme file