### PR TITLE
Fix send test verification before enable it

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ For provider `nexmo`:
 * `NEXMO_FROM` - Specify SMS sender phone number. Default to `NEXMO_FROM`.
 * `SMS_TEXT_URL` - Specify the URL of the SMS content template.
 
+### Verify test provider settings
+
+The plugin provides test api for testing verification email and SMS. Provider
+settings are provided by environment variable and api parameters. The test api
+will merge the setting from environment variable and api parameters, so plugin
+can provide default provider settings and api can overwrite the setting by api
+parameters. The default provider settings are prefixed with
+`VERIFY_TEST_<provider>_PROVIDER_`. For example, set
+`VERIFY_TEST_SMTP_PROVIDER_SUBJECT` to set the testing verification email
+default subject.
+
 ## Templates
 
 This plugin provides basic HTML and email templates for handling forgot

--- a/forgot_password/__init__.py
+++ b/forgot_password/__init__.py
@@ -20,24 +20,29 @@ from .settings import \
     get_settings_parser, \
     get_smtp_settings_parser, \
     get_welcome_email_settings_parser, \
-    get_verify_settings_parser
+    get_verify_settings_parser, \
+    get_verify_test_provider_settings_parser
 from .handlers import register_handlers
 
+test_providers = []
 import_exc_info = True
 try:
     from .providers import nexmo  # noqa
+    test_providers.append('nexmo')
 except ImportError as e:
     logging.warn('Unable to import nexmo provider.'
                  ' Is `nexmo` package installed?',
                  exc_info=import_exc_info)
 try:
     from .providers import twilio  # noqa
+    test_providers.append('twilio')
 except ImportError as e:
     logging.warn('Unable to import twilio provider.'
                  ' Is `twilio` package installed?',
                  exc_info=import_exc_info)
 try:
     from .providers import smtp  # noqa
+    test_providers.append('smtp')
 except ImportError as e:
     logging.warn('Unable to import smtp provider.'
                  ' Is `pyzmail36` package installed?',
@@ -46,11 +51,17 @@ from .providers import debug  # noqa
 
 
 def includeme(settings):
+    verify_test_providers = {}
+    for provider in test_providers:
+        verify_test_providers[provider] = getattr(
+            settings, 'verify_test_provider_{}'.format(provider), {})
+
     register_handlers(
         settings=settings.forgot_password,
         smtp_settings=settings.forgot_password_smtp,
         welcome_email_settings=settings.forgot_password_welcome_email,
-        verify_settings=settings.verify
+        verify_settings=settings.verify,
+        verify_test_provider_settings=verify_test_providers
     )
 
 
@@ -60,3 +71,6 @@ add_setting_parser('forgot_password_welcome_email',
                    get_welcome_email_settings_parser())
 add_setting_parser('verify',
                    get_verify_settings_parser())
+for provider in test_providers:
+    add_setting_parser('verify_test_provider_{}'.format(provider),
+                       get_verify_test_provider_settings_parser(provider))

--- a/forgot_password/handlers/__init__.py
+++ b/forgot_password/handlers/__init__.py
@@ -41,4 +41,5 @@ def register_handlers(**kwargs):
                                      **kwargs)
     register_welcome_email_hooks_and_ops(template_provider=template_provider,
                                          **kwargs)
-    register_verify_code(kwargs['verify_settings'])
+    register_verify_code(kwargs['verify_settings'],
+                         kwargs['verify_test_provider_settings'])

--- a/forgot_password/providers/nexmo/__init__.py
+++ b/forgot_password/providers/nexmo/__init__.py
@@ -69,7 +69,8 @@ class NexmoProvider:
         if success:
             logger.info('Sent SMS to `%s`. msg=%s', recipient, msg)
         else:
-            raise Exception('unable to send SMS')
+            error_message = response.get('error-text', '')
+            raise Exception('Unable to send SMS: %s' % error_message)
 
 
 register_provider_class('nexmo', NexmoProvider)

--- a/forgot_password/settings.py
+++ b/forgot_password/settings.py
@@ -319,3 +319,18 @@ def get_verify_settings_parser_for_key_and_provider(key, provider):
     provider_class = get_provider_class(provider)
     provider_class.configure_parser(key, parser)
     return parser
+
+
+def get_verify_test_provider_settings_parser(provider):
+    """
+    Returns a parser for parsing verify test provider settings.
+    """
+    parser = SettingsParser('VERIFY_TEST_{}_PROVIDER'.format(provider.upper()))
+    provider_class = get_provider_class(provider)
+    provider_class.configure_parser('test', parser)
+    for key in parser.settings:
+        # plugin will try to get the provider config for test verification api
+        # the config is not necessarily required.
+        # For example, nexmo and twilio are provided by user from test api
+        parser.settings[key] = parser.settings[key]._replace(required=False)
+    return parser


### PR DESCRIPTION
The fix handled when user call test email and sms api before enabling the verification methods in plugin. The plugin will try to get the all providers config as the default config, those config is not necessarily required as they are the default only. User who call the test api can provide provider setting in testing api payload to overwrite the default config.