### PR TITLE
Fix fail to use record key's error template and redirect when user click consumed verification link

### DIFF
--- a/forgot_password/handlers/util/verify_code.py
+++ b/forgot_password/handlers/util/verify_code.py
@@ -29,8 +29,7 @@ def get_verify_code(c, auth_id, code):
     # for the same verification code
     stmt = select([code_table]) \
         .where(and_(code_table.c.auth_id == auth_id,
-                    code_table.c.code == code,
-                    code_table.c.consumed == False)) \
+                    code_table.c.code == code)) \
         .order_by(desc(code_table.c.created_at))  # noqa
     result = c.execute(stmt)
     return result.fetchone()

--- a/forgot_password/handlers/verify_code.py
+++ b/forgot_password/handlers/verify_code.py
@@ -245,7 +245,7 @@ class VerifyCodeLambda:
     def __call__(self, auth_id, code_str):
         with conn() as c:
             code = get_verify_code(c, auth_id, code_str)
-            if not code:
+            if not code or code.consumed:
                 msg = 'the code `{}` is not valid ' \
                       'for user `{}`'.format(code_str, auth_id)
                 raise SkygearException(msg, skyerror.InvalidArgument)


### PR DESCRIPTION
Update `get_verify_code` to return consumed code when verifying code, check if the code is consumed in runtime. So that we can get the record key from code and use corresponding error template and redirect.