### PR TITLE
Replace hook param `async` by `async_`

### DIFF
--- a/forgot_password/handlers/verify_code.py
+++ b/forgot_password/handlers/verify_code.py
@@ -94,7 +94,7 @@ def register(settings, test_provider_settings):  # noqa
         thelambda = VerifyRequestLambda(settings, providers)
         return thelambda(current_user_id(), record_key)
 
-    @skygear.before_save('user', async=False)  # noqa: NOTE(cheungpat): W606
+    @skygear.before_save('user', async_=False)
     def before_user_save_hook(record, original_record, db):
         """
         Checks the user record for data changes so that verified flag
@@ -103,7 +103,7 @@ def register(settings, test_provider_settings):  # noqa
         record = update_flags(settings, record, original_record, db)
         return record
 
-    @skygear.after_save('user', async=True)  # noqa: NOTE(cheungpat): W606
+    @skygear.after_save('user', async_=True)
     def after_user_save_hook(record, original_record, db):
         """
         Performs action upon saving user record such as sending verifications.

--- a/forgot_password/handlers/welcome_email.py
+++ b/forgot_password/handlers/welcome_email.py
@@ -70,7 +70,7 @@ def register_hooks_and_ops(**kwargs):
 
 
 def register_hooks(mail_sender, settings, welcome_email_settings):
-    @skygear.after_save('user', async=True)  # noqa: NOTE(cheungpat): W606
+    @skygear.after_save('user', async_=True)
     def user_after_save(record, original_record, db):
         if original_record:
             # ignore for old users

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
       install_requires=[
             'Jinja2>=2.8',
             'pyzmail36>=1.0.3',
-            'skygear>=0.16.0',
+            'skygear>=1.6.0',
             'nexmo>=2.0.0',
             'twilio>=6.10.4'
       ],


### PR DESCRIPTION
To avoid syntax error when running using Python 3.7+, where `async`
becomes a reserved keyword, as py-skygear 1.6.0 starts to accept
`async_` as hook param in addition to `async`.